### PR TITLE
Make BlizzardApi::Wow.character an alias for .character_profile.

### DIFF
--- a/lib/blizzard_api/wow.rb
+++ b/lib/blizzard_api/wow.rb
@@ -276,10 +276,13 @@ module BlizzardApi
     end
 
     ##
+    # Alias for {character_profile}.
+    #
     # @param region [String] API Region
-    # @return {Character}
+    # @return {CharacterProfile}
+    # @see character_profile
     def self.character(region = BlizzardApi.region)
-      BlizzardApi::Wow::Character.new(region)
+      character_profile(region)
     end
 
     require_relative 'wow/profile/profile'


### PR DESCRIPTION
Hi! Thanks for the gem!

While trying it out, I discovered `BlizzardApi::Wow.character` was attempting to create a `BlizzardApi::Wow::Character` object, which does not exist. This change just calls `BlizzardApi::Wow.character_profile`, which uses BlizzardApi::Wow::CharacterProfile instead. If you prefer, I could just delete `BlizzardApi::Wow.character` completely, but I thought just making it an alias rather than removing it would be more backwards-compatible.